### PR TITLE
Add support for pug (jade) templates

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "license": "MIT",
   "dependencies": {
     "app-root-path": "^1.0.0",
-    "node-static": "^0.7.7"
+    "express": "^4.14.0",
+    "pug": "^2.0.0-beta3"
   },
   "devDependencies": {
     "electron-prebuilt": "^1.2.4"

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -108,7 +108,7 @@ function openAddServerDialog() {
   let addServerWindow = new BrowserWindow({
     title: 'Add a server', 
     width: 250, 
-    height: 330, 
+    height: 355, 
     resizable: false, 
     autoHideMenuBar: true, 
     icon: path.join(__dirname, '/assets/icons/tray-icon.png')

--- a/src/renderers/add-server-renderer.js
+++ b/src/renderers/add-server-renderer.js
@@ -7,6 +7,7 @@ let directoryLabel = document.getElementById('directory-label');
 let closeButton = document.getElementById('close-button');
 let saveButton = document.getElementById('save-button');
 let portInput = document.getElementById('port-input');
+let pugInput = document.getElementById('pug-input');
 //let indexInput = document.getElementById('index-input');
 //let downloadInput = document.getElementById('download-input');
 let startInput = document.getElementById('start-input');
@@ -31,6 +32,7 @@ saveButton.addEventListener('click', () => {
   let options = {
     path: directoryInput.value,
     port: portInput.value,
+    pug: pugInput.checked,
     //autoIndex: indexInput.checked,
     //download: downloadInput.checked,
     isActive: startInput.checked

--- a/views/add-server.html
+++ b/views/add-server.html
@@ -24,6 +24,11 @@
           </div>
           <div class="checkbox">
             <label>
+              <input type="checkbox" id="pug-input" name="start"> Enable pug (jade) templates
+            </label>
+          </div>
+          <div class="checkbox">
+            <label>
               <input type="checkbox" id="start-input" name="start" checked> Start the server
             </label>
           </div>


### PR DESCRIPTION
- Add an option to enable pug (jade) templates in the UI
- Switch from node-static to express to be able to use middlewares
- Use pug rendering middleware if the user checked the pug option
